### PR TITLE
Downgrade byteorder to get some updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ include = ["src/**/*", "Cargo.toml"]
 [dependencies]
 bytes = "0.4"
 protobuf = "2.8"
-byteorder = "1.3.2"
+byteorder = "0.5.3"
 integer-encoding = "1.0.5"
 log = "0.4.8"
 env_logger = "0.6.2"


### PR DESCRIPTION
This change should force Dependabot to update the version requirement as `^0.5.3` doesn't match `1.3.2`.